### PR TITLE
Allow to extend others props on the VirtualizedList

### DIFF
--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -196,6 +196,7 @@ export default class MasonryList extends Component {
       ListHeaderComponent,
       keyExtractor,
       onEndReached,
+      ...props
     } = this.props;
     let headerElement;
     if (ListHeaderComponent) {
@@ -211,6 +212,7 @@ export default class MasonryList extends Component {
         {(!headerElement || this.state.headerHeight !== null) &&
           this.state.columns.map(col => (
             <VirtualizedList
+              {...props}
               ref={ref => (this._listRefs[col.index] = ref)}
               key={`$col_${col.index}`}
               data={col.data}


### PR DESCRIPTION
Hi, i am so happy that i found this project, thank you so much.

I was trying to add some props from the VirtualizedList, but no extra props is added to the VirtualizedList in the same way that FlatList [does](https://github.com/facebook/react-native/blob/master/Libraries/Lists/FlatList.js#L548), and i am also aware that's not all props that works with the way the masonry works (such debug prop),  but i mean more in basic props such as `initialNumToRender` and `windowSize`.

Could we add this? 
Thank you.