### PR TITLE
Prevent onEndReached from getting called multiple times

### DIFF
--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -118,7 +118,7 @@ export default class MasonryList extends React.Component<Props, State> {
   state = _stateFromProps(this.props);
   _listRefs: Array<?VirtualizedList> = [];
   _scrollRef: ?ScrollView;
-  _endsReached = 0;
+  _endReached = false;
 
   componentWillReceiveProps(newProps: Props) {
     this.setState(_stateFromProps(newProps));
@@ -196,6 +196,23 @@ export default class MasonryList extends React.Component<Props, State> {
     );
   };
 
+  _onEndReached = event => {
+    if (this._endReached) {
+      return;
+    }
+
+    this._endReached = true;
+
+    if (this.props.onEndReached) {
+      this.props.onEndReached(event);
+    }
+
+    // small lag to avoid _onEndReached getting double called by multiple columns
+    setTimeout(() => {
+      this._endReached = false;
+    }, 200);
+  };
+
   _getItemLayout = (columnIndex, rowIndex) => {
     const column = this.state.columns[columnIndex];
     let offset = 0;
@@ -242,7 +259,7 @@ export default class MasonryList extends React.Component<Props, State> {
               renderItem({ item, index, column: col.index })}
             renderScrollComponent={this._renderScrollComponent}
             keyExtractor={keyExtractor}
-            onEndReached={onEndReached}
+            onEndReached={this._onEndReached}
             onEndReachedThreshold={this.props.onEndReachedThreshold}
             removeClippedSubviews={false}
           />,

--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -81,7 +81,7 @@ type State = {
 };
 
 // This will get cloned and added a bunch of props that are supposed to be on
-// ScrollView so we wan't to make sure we don't pass them over (especially
+// ScrollView so we want to make sure we don't pass them over (especially
 // onLayout since it exists on both).
 class FakeScrollView extends React.Component<{ style?: any, children?: any }> {
   render() {
@@ -196,6 +196,9 @@ export default class MasonryList extends React.Component<Props, State> {
     );
   };
 
+  /**
+   * Temporary workaround for onEndReached getting called by each column
+   */
   _onEndReached = event => {
     if (this._endReached) {
       return;
@@ -207,7 +210,7 @@ export default class MasonryList extends React.Component<Props, State> {
       this.props.onEndReached(event);
     }
 
-    // small lag to avoid _onEndReached getting double called by multiple columns
+    // small lag to avoid _onEndReached getting called by multiple columns
     setTimeout(() => {
       this._endReached = false;
     }, 200);


### PR DESCRIPTION
This is a bit of a hack that fixes #13 

If you had something different in mind for this fix, maybe we can use this as a starting point to figuring out a more proper solution.

We're depending on redux actions to handle our version of `setState({ loading: true })`. For whatever reason, the two column masonry layout fires both events too closely together for our  the redux action to capture it in time.

P.S. this PR renames and repurposes the unused `this._endsReached` class property.