### PR TITLE
Add custom key and listKey to allow multiple VirtualizedList

### DIFF
--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -221,7 +221,6 @@ export default class MasonryList extends React.Component<Props, State> {
       ListEmptyComponent,
       keyExtractor,
       onEndReached,
-      key,
       listKey,
       ...props
     } = this.props;
@@ -240,7 +239,7 @@ export default class MasonryList extends React.Component<Props, State> {
           <VirtualizedList
             {...props}
             ref={ref => (this._listRefs[col.index] = ref)}
-            key={`${key}_${col.index}`}
+            key={`${listKey}_${col.index}`}
             listKey={`${listKey}_${col.index}`}
             data={col.data}
             getItemCount={this._getItemCount}

--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -47,6 +47,11 @@ export type Props = {
   renderItem: ({ item: any, index: number, column: number }) => ?React.Element<
     any,
   >,
+  onViewableItemsChanged: ({
+    viewableItems: Array<any>,
+    changed: Array<any>,
+    column: number,
+  }) => void,
   getHeightForItem: ({ item: any, index: number }) => number,
   ListHeaderComponent?: ?React.ComponentType<any>,
   ListEmptyComponent?: ?React.ComponentType<any>,
@@ -222,6 +227,7 @@ export default class MasonryList extends React.Component<Props, State> {
       keyExtractor,
       onEndReached,
       listKey,
+      onViewableItemsChanged,
       ...props
     } = this.props;
     let headerElement;
@@ -253,6 +259,13 @@ export default class MasonryList extends React.Component<Props, State> {
             onEndReached={onEndReached}
             onEndReachedThreshold={this.props.onEndReachedThreshold}
             removeClippedSubviews={false}
+            onViewableItemsChanged={({ viewableItems, changed }) =>
+              onViewableItemsChanged &&
+              onViewableItemsChanged({
+                viewableItems,
+                changed,
+                column: col.index,
+              })}
           />,
         )}
       </View>

--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -221,6 +221,8 @@ export default class MasonryList extends React.Component<Props, State> {
       ListEmptyComponent,
       keyExtractor,
       onEndReached,
+      key,
+      listKey,
       ...props
     } = this.props;
     let headerElement;
@@ -238,7 +240,8 @@ export default class MasonryList extends React.Component<Props, State> {
           <VirtualizedList
             {...props}
             ref={ref => (this._listRefs[col.index] = ref)}
-            key={`$col_${col.index}`}
+            key={`${key}_${col.index}`}
+            listKey={`${listKey}_${col.index}`}
             data={col.data}
             getItemCount={this._getItemCount}
             getItem={this._getItem}


### PR DESCRIPTION
Allows the use of a custom key and listKey to enable multiple VirtualizedList inside another VirtualizedList. Without this, doing so would result in an invariant error.